### PR TITLE
Implement A* path finding.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *_pb2.py
+*~

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ all: reset/proto/types_pb2.py reset/proto/commands_pb2.py reset/proto/events_pb2
 reset/proto/%_pb2.py: reset/proto/%.proto
 	protoc -Ireset/proto --python_out=reset/proto $^
 	sed -i 's/^import \(.*\)_pb2/from reset.proto import \1_pb2/' $@
-	sed -i 's/import \(.*\)_pb2 as \1__pb2/from reset.proto import \1_pb2 as \1__pb2/' $@
+	sed -i 's/^import \(.*\)_pb2 as \1__pb2/from reset.proto import \1_pb2 as \1__pb2/' $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ curio>=0.9
 noise>=1.2
 protobuf>=3.6
 wsproto>=0.12
+HeapDict>=1.0.0

--- a/reset/client/__main__.py
+++ b/reset/client/__main__.py
@@ -67,7 +67,7 @@ async def main():
 	protocol = ProtocolUser(rules)
 	client = Client(args.host, args.port, protocol)
 	async with util.ScopeTask(client.run()):
-		cli_task = await curio.spawn(cli(pargs, rules, client))
+		cli_task = await curio.spawn(cli(args, rules, client))
 		if args.join:
 			await command_join(client, [])
 		if args.start:

--- a/reset/proto/events.proto
+++ b/reset/proto/events.proto
@@ -28,6 +28,7 @@ message ServerToClient {
 		EventUnitCreate event_unit_create = 40;
 		EventUnitUpdate event_unit_update = 41;
 		EventUnitDestroy event_unit_destroy = 42;
+		EventUnitMove event_unit_move = 43;
 
 		EventActionQueued event_action_queued = 50;
 		EventActionUpdate event_action_update = 51;

--- a/reset/server/__init__.py
+++ b/reset/server/__init__.py
@@ -238,7 +238,7 @@ class ProtocolGame(Protocol):
 				raise game.GameError("This action does not work on cells")
 			if not (0 <= target_cell[0] < self.map.width and 0 <= target_cell[1] < self.map.height):
 				raise game.GameError("Target cell is not inside the map")
-			if not action_type.target_types <= target_cell.tags:
+			if not action_type.target_tags <= self.map[target_cell].terrain_type.tags:
 				raise game.GameError("Target cell does not have the necessary tags")
 
 		action = await self.map.action_queue(action_type, unit, message.mode, target_unit, target_cell)

--- a/reset/server/game.py
+++ b/reset/server/game.py
@@ -234,6 +234,20 @@ class Map:
 		await unit.queue_action(action)
 		return action
 
+	async def move_unit(self, unit, destination):
+		cell = self[destination]
+		if 'walk' not in cell.terrain_type.tags:
+			raise GameError("cannot move unit to unwalkable cell")
+		unit_pos = self.get_location(unit)
+		if abs(unit_pos[0] - destination[0]) > 1 or abs(unit_pos[1] - destination[1]) > 1:
+			raise GameError("can only move unit to neighboring cell")
+		if cell.unit is not None:
+			raise GameError("cells can only hold one unit")
+		cell.unit = unit
+		self[unit_pos].unit = None
+		await self.events.put(('UNIT_MOVE', unit, destination))
+
+
 
 def vicinity(xy, width, height):
 	'''Generate coordinates starting at xy and gradually moving further away

--- a/reset/server/pathfinder.py
+++ b/reset/server/pathfinder.py
@@ -1,0 +1,94 @@
+import math
+from heapdict import heapdict
+from .game import vicinity
+
+
+class PathFinder:
+	"""
+	Implement path finding using A*.
+	"""
+
+	def __init__(self, map):
+		self.map = map
+
+	def _idx(self, pos):
+		x, y = pos
+		return y * self.map.width + x
+
+	def plan(self, start_pos, dest_pos):
+		"""
+		Search a path from start_pos to dest_pos.
+
+		Returns a list of walkable positions forming a path from
+		start_pos to dest_pos. Ignores whether any units are in the
+		way. If no path to dest_pos can be found, returns a path to a
+		nearby reachable position.
+		"""
+
+		map_size = self.map.width * self.map.height
+		dist = [float('inf') for i in range(map_size)]
+		prev = [None for i in range(map_size)]
+
+		dist[self._idx(start_pos)] = 0
+
+		pq = heapdict()
+		for y in range(self.map.height):
+			for x in range(self.map.width):
+				pq[x, y] = dist[self._idx((x, y))]
+
+		while pq:
+			pos, _ = pq.popitem()
+			x, y = pos
+
+			for nx, ny in self._neighbors(x, y):
+				new_dist = dist[self._idx(pos)] + 1
+				if new_dist < dist[self._idx((nx, ny))]:
+					dist[self._idx((nx, ny))] = new_dist
+					# Heuristic function is only admissible if it never
+					# overestimates true costs. Because diagonals only
+					# have costs of 1, we cannot use the euclidian
+					# distance as heuristic. Instead, we use the chebyshev
+					# distance.
+					pq[nx, ny] = new_dist + chebyshev_distance((nx, ny), dest_pos)
+					prev[self._idx((nx, ny))] = x, y
+
+		if math.isinf(dist[self._idx(dest_pos)]):
+			for point in vicinity(dest_pos, self.map.width, self.map.height):
+				if not math.isinf(dist[self._idx(point)]):
+					dest_pos = point
+					break
+			else:
+				raise ValueError("cannot find a path")
+
+		return self._reconstruct_path(start_pos, dest_pos, prev)
+
+	def _neighbors(self, x, y):
+		offsets = [
+			(-1, -1), (-1, 0), (-1, 1),
+			(0, -1), (0, 1),
+			(1, -1), (1, 0), (1, 1)
+		]
+		for x_offs, y_offs in offsets:
+			nx = x + x_offs
+			ny = y + y_offs
+			if nx < 0 or ny < 0 or nx >= self.map.width or ny >= self.map.height:
+				continue
+			if 'walk' not in self.map[nx, ny].terrain_type.tags:
+				continue
+			yield (nx, ny)
+
+	def _reconstruct_path(self, start_pos, dest_pos, prev):
+		next_pos = dest_pos
+		path = []
+		while next_pos != start_pos:
+			path.append(next_pos)
+			next_pos = prev[self._idx(next_pos)]
+		path.reverse()
+		return path
+
+
+def chebyshev_distance(a, b):
+	"""Compute the chebyshev distance, or maximum metric, between a and b."""
+	ax, ay = a
+	bx, by = b
+	return max(abs(ax - bx), abs(ay - by))

--- a/reset/server/pathfinder.py
+++ b/reset/server/pathfinder.py
@@ -75,6 +75,9 @@ class PathFinder:
 				continue
 			if 'walk' not in self.map[nx, ny].terrain_type.tags:
 				continue
+			unit = self.map[nx, ny].unit
+			if unit is not None and ('resource' in unit.unit_type.tags or 'building' in unit.unit_type.tags):
+			    continue
 			yield (nx, ny)
 
 	def _reconstruct_path(self, start_pos, dest_pos, prev):


### PR DESCRIPTION
Create a basic pathfinder using A\* with the [chebychev distance](https://en.wikipedia.org/wiki/Chebyshev_distance) as a heuristic.

A function is only admissible as a heuristic for A\*  if it never overestimates the real costs. Since taking diagonals currently costs 1 instead of sqrt(2), we cannot use the euclidian distance as heuristic, so we use the maximum metric / chebychev distance instead.
 
PathFinder currently ignores whether a map cell is blocked by a unit, we might need to improve that later on, especially if we see a lot of units blocking each other in practice.

Naval or air units are not yet supported.